### PR TITLE
支出リストにおける表示列の入れ替え

### DIFF
--- a/app/routes/auth/expense/index.tsx
+++ b/app/routes/auth/expense/index.tsx
@@ -41,8 +41,8 @@ export default createRoute(async (c) => {
     const headers: TableHeaderItem[] = [
         { name: '日付', textPosition: 'left' },
         { name: 'カテゴリ', textPosition: 'left' },
-        { name: '支払い方法', textPosition: 'left' },
         { name: '金額', textPosition: 'right' },
+        { name: '支払い方法', textPosition: 'left' },
         { name: '説明', textPosition: 'center' },
         { name: '操作', textPosition: 'center' }
     ]
@@ -73,11 +73,11 @@ export default createRoute(async (c) => {
                                 <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
                                     {expense.category_name}
                                 </td>
-                                <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
-                                    {expense.payment_method_name}
-                                </td>
                                 <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500 text-right">
                                     {expense.amount.toLocaleString()} 円
+                                </td>
+                                <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                                    {expense.payment_method_name}
                                 </td>
                                 <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500 text-center">
                                     {expense.description || '-'}


### PR DESCRIPTION
要件を確認したところ支出リストを確認する際に金額が見えればいいだけだった。
日付、カテゴリ、支払い方法、金額となっている表示順を日付、カテゴリ、金額、支払い方法に変えるだけにした。