### PR TITLE
Increase default list display count to improve user experience #8

### DIFF
--- a/app/routes/auth/asset/index.tsx
+++ b/app/routes/auth/asset/index.tsx
@@ -10,11 +10,12 @@ import { getCookie } from 'hono/cookie'
 import { successAlertCookieKey, dangerAlertCookieKey } from '@/settings/kakeiboSettings'
 import { AssetCreateModal } from '@/islands/asset/AssetCreateModal'
 import { Table } from '@/components/share/Table'
+import { kakeiboPerPage } from '@/settings/kakeiboSettings'
 
 export default createRoute(async (c) => {
     let page = c.req.query('page') ?? '1'
     const p = parseInt(page)
-    const limit = 10
+    const limit = kakeiboPerPage
     const offset = limit * (p - 1)
     const client = new KakeiboClient({ token: c.env.HONO_IS_COOL, baseUrl: c.env.BASE_URL })
     const assets = await client.getListResponse<AssetWithCategoryResponse>({

--- a/app/routes/auth/expense/index.tsx
+++ b/app/routes/auth/expense/index.tsx
@@ -10,11 +10,12 @@ import { successAlertCookieKey } from '@/settings/kakeiboSettings'
 import { ExpenseDeleteModal } from '@/islands/expense/ExpenseDeleteModal'
 import { ExpenseCreateModal } from '@/islands/expense/ExpenseCreateModal'
 import { Table } from '@/components/share/Table'
+import { kakeiboPerPage } from '@/settings/kakeiboSettings'
 
 export default createRoute(async (c) => {
     let page = c.req.query('page') ?? '1'
     const p = parseInt(page)
-    const limit = 10
+    const limit = kakeiboPerPage
     const offset = limit * (p - 1)
     const client = new KakeiboClient({ token: c.env.HONO_IS_COOL, baseUrl: c.env.BASE_URL })
     const expenses = await client.getListResponse<ExpenseWithDetailsResponse>({

--- a/app/routes/auth/income/index.tsx
+++ b/app/routes/auth/income/index.tsx
@@ -10,11 +10,12 @@ import { successAlertCookieKey } from '@/settings/kakeiboSettings'
 import { IncomeDeleteModal } from '@/islands/income/IncomeDeleteModal'
 import { IncomeCreateModal } from '@/islands/income/IncomeCreateModal'
 import { Table } from '@/components/share/Table'
+import { kakeiboPerPage } from '@/settings/kakeiboSettings'
 
 export default createRoute(async (c) => {
     let page = c.req.query('page') ?? '1'
     const p = parseInt(page)
-    const limit = 10
+    const limit = kakeiboPerPage
     const offset = limit * (p - 1)
     const client = new KakeiboClient({ token: c.env.HONO_IS_COOL, baseUrl: c.env.BASE_URL })
     const incomes = await client.getListResponse<IncomeWithCategoryResponse>({

--- a/app/settings/kakeiboSettings.ts
+++ b/app/settings/kakeiboSettings.ts
@@ -1,4 +1,3 @@
-
 // グラフのカラーチャート。python seabornより sns paired
 export const colorSchema = ['rgba(166.65098039215687,206.8078431372549,227.89019607843136,0.6)',
     'rgba(31.12156862745098,120.47058823529412,180.7058823529412,0.6)',
@@ -67,3 +66,5 @@ export const successAlertCookieKey = 'successMessage'
 export const dangerAlertCookieKey = 'dangerMessage'
 // alertメッセージの保持期間
 export const alertCookieMaxage = 1
+// リスト系ページの表示件数
+export const kakeiboPerPage = 30


### PR DESCRIPTION
### リスト画面の表示件数を増加 (#8)

#### 概要
リスト画面の表示件数を増やし、ユーザーが頻繁にページを切り替える必要を減らし、利便性を向上させる。今回の変更では、以下の修正を行った。

#### 主な変更点
1. **`kakeiboSettings.ts` に定数 `kakeiboPerPage` を追加**  
   - 表示件数を一元管理するため、リストの表示件数を設定する定数 `kakeiboPerPage` を 30 に設定した。
2. **既存のリスト関連コードを修正**  
   - 各リスト系ページ (`auth/asset`, `auth/expense`, `auth/income`) の `limit` 値を `kakeiboPerPage` に置き換えた。

#### 修正対象
- `app/routes/auth/asset/index.tsx`
- `app/routes/auth/expense/index.tsx`
- `app/routes/auth/income/index.tsx`
- `app/settings/kakeiboSettings.ts`

#### 動作確認
- ローカル環境にて、リスト画面が 30 件表示に変更されていることを確認した。
- ページングが正しく動作することを確認した。

#### その他
- 今後、表示件数の調整が必要な場合は `kakeiboSettings.ts` 内の `kakeiboPerPage` を修正するだけで対応可能である。
