### PR TITLE
Fix: Redirect to the correct page after editing data and highlight the last updated row

### DIFF
--- a/app/routes/auth/asset/[id]/update.tsx
+++ b/app/routes/auth/asset/[id]/update.tsx
@@ -58,5 +58,5 @@ export const POST = createRoute(
         const response = await client.updateData<Asset>({ endpoint: 'asset', contentId: id, data: body })
             .catch((e) => { console.error(e) })
         setCookie(c, successAlertCookieKey, '資産編集に成功しました', { maxAge: alertCookieMaxage })
-        return c.redirect(`/auth/asset?page=${redirectPage}`, 303);
+        return c.redirect(`/auth/asset?page=${redirectPage}&lastUpdate=${id}`, 303);
     })

--- a/app/routes/auth/asset/[id]/update.tsx
+++ b/app/routes/auth/asset/[id]/update.tsx
@@ -23,6 +23,7 @@ export const POST = createRoute(
     }),
     async (c) => {
         const id = c.req.param('id')
+        const redirectPage = c.req.query('redirectPage')
         const client = new KakeiboClient({ token: c.env.HONO_IS_COOL, baseUrl: c.env.BASE_URL })
         const { date, amount, asset_category_id, description } = c.req.valid('form')
         const parsedAmount = Number(amount);
@@ -57,5 +58,5 @@ export const POST = createRoute(
         const response = await client.updateData<Asset>({ endpoint: 'asset', contentId: id, data: body })
             .catch((e) => { console.error(e) })
         setCookie(c, successAlertCookieKey, '資産編集に成功しました', { maxAge: alertCookieMaxage })
-        return c.redirect('/auth/asset', 303);
+        return c.redirect(`/auth/asset?page=${redirectPage}`, 303);
     })

--- a/app/routes/auth/asset/create.tsx
+++ b/app/routes/auth/asset/create.tsx
@@ -37,7 +37,7 @@ export const POST = createRoute(
         }
         const [yearStr, monthStr] = date.split("-");
         const year = parseInt(yearStr, 10);
-        const month = parseInt(monthStr, 10); 
+        const month = parseInt(monthStr, 10);
         const ge = getBeginningOfMonth(year, month)
         const le = getEndOfMonth(year, month)
         const r = await client.getListResponse<AssetWithCategoryResponse>({
@@ -51,6 +51,8 @@ export const POST = createRoute(
         }
         const response = await client.addData<Asset>({ endpoint: 'asset', data: body })
             .catch((e) => { console.error(e) })
-        setCookie(c, successAlertCookieKey, '資産追加に成功しました', { maxAge: alertCookieMaxage })
-        return c.redirect('/auth/asset', 303);
+        if (response) {
+            setCookie(c, successAlertCookieKey, '資産追加に成功しました', { maxAge: alertCookieMaxage })
+            return c.redirect(`/auth/asset?lastUpdate=${response.id}`, 303);
+        }
     })

--- a/app/routes/auth/asset/index.tsx
+++ b/app/routes/auth/asset/index.tsx
@@ -83,7 +83,7 @@ export default createRoute(async (c) => {
                                             description: asset.description || ''
                                         }}
                                         title='編集'
-                                        actionUrl={`/auth/asset/${asset.id}/update`}
+                                        actionUrl={`/auth/asset/${asset.id}/update?redirectPage=${page}`}
                                         categories={categories}>
                                     </AssetCreateModal>
                                     <AssetCreateModal

--- a/app/routes/auth/asset/index.tsx
+++ b/app/routes/auth/asset/index.tsx
@@ -41,6 +41,9 @@ export default createRoute(async (c) => {
         { name: '説明', textPosition: 'center' },
         { name: '操作', textPosition: 'center' }
     ]
+    const lastUpdate = c.req.query('lastUpdate') ?? '0'
+    const lastUpdateId = parseInt(lastUpdate)
+
     return c.render(
         <>
             <div className="px-4 sm:px-6 lg:px-8">
@@ -59,7 +62,8 @@ export default createRoute(async (c) => {
                 <Table headers={headers}>
                     <tbody className="divide-y divide-gray-200 bg-white">
                         {assets.contents.map((asset) => (
-                            <tr key={asset.id} className="hover:bg-gray-50">
+                            <tr key={asset.id}
+                                className={`hover:bg-gray-50 ${asset.id === lastUpdateId ? 'bg-green-100' : ''}`}>
                                 <td className="whitespace-nowrap py-4 pl-6 text-sm text-gray-900">
                                     {asset.date}
                                 </td>

--- a/app/routes/auth/expense/[id]/update.tsx
+++ b/app/routes/auth/expense/[id]/update.tsx
@@ -43,5 +43,5 @@ export const POST = createRoute(
         const response = await client.updateData<Expense>({ endpoint: 'expense', contentId: id, data: body })
             .catch((e) => { console.error(e) })
         setCookie(c, successAlertCookieKey, '支出編集に成功しました', { maxAge: alertCookieMaxage })
-        return c.redirect(`/auth/expense?page=${redirectPage}`, 303);
+        return c.redirect(`/auth/expense?page=${redirectPage}&lastUpdate=${id}`, 303);
     })

--- a/app/routes/auth/expense/[id]/update.tsx
+++ b/app/routes/auth/expense/[id]/update.tsx
@@ -24,6 +24,7 @@ export const POST = createRoute(
     }),
     async (c) => {
         const id = c.req.param('id')
+        const redirectPage = c.req.query('redirectPage')
         const client = new KakeiboClient({ token: c.env.HONO_IS_COOL, baseUrl: c.env.BASE_URL })
         const { date, amount, expense_category_id, payment_method_id, description } = c.req.valid('form')
         const parsedAmount = Number(amount);
@@ -42,5 +43,5 @@ export const POST = createRoute(
         const response = await client.updateData<Expense>({ endpoint: 'expense', contentId: id, data: body })
             .catch((e) => { console.error(e) })
         setCookie(c, successAlertCookieKey, '支出編集に成功しました', { maxAge: alertCookieMaxage })
-        return c.redirect('/auth/expense', 303);
+        return c.redirect(`/auth/expense?page=${redirectPage}`, 303);
     })

--- a/app/routes/auth/expense/create.tsx
+++ b/app/routes/auth/expense/create.tsx
@@ -39,6 +39,8 @@ export const POST = createRoute(
         }
         const response = await client.addData<Expense>({ endpoint: 'expense', data: body })
             .catch((e) => { console.error(e) })
-        setCookie(c, successAlertCookieKey, '支出追加に成功しました', { maxAge: alertCookieMaxage })
-        return c.redirect('/auth/expense', 303);
+        if (response) {
+            setCookie(c, successAlertCookieKey, '支出追加に成功しました', { maxAge: alertCookieMaxage })
+            return c.redirect(`/auth/expense?lastUpdate=${response.id}`, 303);
+        }
     })

--- a/app/routes/auth/expense/index.tsx
+++ b/app/routes/auth/expense/index.tsx
@@ -47,6 +47,8 @@ export default createRoute(async (c) => {
         { name: '説明', textPosition: 'center' },
         { name: '操作', textPosition: 'center' }
     ]
+    const lastUpdate = c.req.query('lastUpdate') ?? '0'
+    const lastUpdateId = parseInt(lastUpdate)
 
     return c.render(
         <>
@@ -67,7 +69,8 @@ export default createRoute(async (c) => {
                 <Table headers={headers}>
                     <tbody className="divide-y divide-gray-200 bg-white">
                         {expenses.contents.map((expense) => (
-                            <tr key={expense.id} className="hover:bg-gray-50">
+                            <tr key={expense.id}
+                                className={`hover:bg-gray-50 ${expense.id === lastUpdateId ? 'bg-green-100' : ''}`}>
                                 <td className="whitespace-nowrap py-4 pl-6 text-sm text-gray-900">
                                     {expense.date}
                                 </td>

--- a/app/routes/auth/expense/index.tsx
+++ b/app/routes/auth/expense/index.tsx
@@ -95,7 +95,7 @@ export default createRoute(async (c) => {
                                             description: expense.description || ''
                                         }}
                                         title='編集'
-                                        actionUrl={`/auth/expense/${expense.id}/update`}
+                                        actionUrl={`/auth/expense/${expense.id}/update?redirectPage=${page}`}
                                         categories={categories}
                                         payment_methods={paymentMethods}>
                                     </ExpenseCreateModal>

--- a/app/routes/auth/income/[id]/update.tsx
+++ b/app/routes/auth/income/[id]/update.tsx
@@ -40,5 +40,5 @@ export const POST = createRoute(
         const response = await client.updateData<Income>({ endpoint: 'income', contentId: id, data: body })
             .catch((e) => { console.error(e) })
         setCookie(c, successAlertCookieKey, '収入編集に成功しました', { maxAge: alertCookieMaxage })
-        return c.redirect(`/auth/income?page=${redirectPage}`, 303);
+        return c.redirect(`/auth/income?page=${redirectPage}&lastUpdate=${id}`, 303);
     })

--- a/app/routes/auth/income/[id]/update.tsx
+++ b/app/routes/auth/income/[id]/update.tsx
@@ -23,6 +23,7 @@ export const POST = createRoute(
     }),
     async (c) => {
         const id = c.req.param('id')
+        const redirectPage = c.req.query('redirectPage')
         const client = new KakeiboClient({ token: c.env.HONO_IS_COOL, baseUrl: c.env.BASE_URL })
         const { date, amount, income_category_id, description } = c.req.valid('form')
         const parsedAmount = Number(amount);
@@ -39,5 +40,5 @@ export const POST = createRoute(
         const response = await client.updateData<Income>({ endpoint: 'income', contentId: id, data: body })
             .catch((e) => { console.error(e) })
         setCookie(c, successAlertCookieKey, '収入編集に成功しました', { maxAge: alertCookieMaxage })
-        return c.redirect('/auth/income', 303);
+        return c.redirect(`/auth/income?page=${redirectPage}`, 303);
     })

--- a/app/routes/auth/income/create.tsx
+++ b/app/routes/auth/income/create.tsx
@@ -36,6 +36,8 @@ export const POST = createRoute(
         }
         const response = await client.addData<Income>({ endpoint: 'income', data: body })
             .catch((e) => { console.error(e) })
-        setCookie(c, successAlertCookieKey, '収入追加に成功しました', { maxAge: alertCookieMaxage })
-        return c.redirect('/auth/income', 303);
+        if (response) {
+            setCookie(c, successAlertCookieKey, '収入追加に成功しました', { maxAge: alertCookieMaxage })
+            return c.redirect(`/auth/income?lastUpdate=${response.id}`, 303);
+        }
     })

--- a/app/routes/auth/income/index.tsx
+++ b/app/routes/auth/income/index.tsx
@@ -81,7 +81,7 @@ export default createRoute(async (c) => {
                                             description: income.description || ''
                                         }}
                                         title='収入編集'
-                                        actionUrl={`/auth/income/${income.id}/update`}
+                                        actionUrl={`/auth/income/${income.id}/update?redirectPage=${page}`}
                                         categories={categories}
                                     >
                                     </IncomeCreateModal>

--- a/app/routes/auth/income/index.tsx
+++ b/app/routes/auth/income/index.tsx
@@ -40,6 +40,8 @@ export default createRoute(async (c) => {
         { name: '説明', textPosition: 'center' },
         { name: '操作', textPosition: 'center' }
     ]
+    const lastUpdate = c.req.query('lastUpdate') ?? '0'
+    const lastUpdateId = parseInt(lastUpdate)
     return c.render(
         <>
             <div className="px-4 sm:px-6 lg:px-8">
@@ -57,7 +59,8 @@ export default createRoute(async (c) => {
                 <Table headers={headers}>
                     <tbody className="divide-y divide-gray-200 bg-white">
                         {incomes.contents.map((income) => (
-                            <tr key={income.id} className="hover:bg-gray-50">
+                            <tr key={income.id}
+                                className={`hover:bg-gray-50 ${income.id === lastUpdateId ? 'bg-green-100' : ''}`}>
                                 <td className="whitespace-nowrap py-4 pl-6 text-sm text-gray-900">
                                     {income.date}
                                 </td>


### PR DESCRIPTION
## 概要
- データ編集後、常に1ページ目に遷移していた問題を修正した。
  - 編集時のページ番号（`redirectPage`）をクエリパラメータとして渡し、編集後に該当ページへリダイレクトするように変更した。

- 最後に編集または作成されたデータを背景色でハイライトする機能を追加した。
  - クエリパラメータで渡された`lastUpdate` IDを用いて、対応するデータ行に背景色を適用するようにした。

## 主な変更点
1. 各データ操作（作成、編集）のリダイレクト先を修正。
   - `redirectPage`パラメータを受け取り、元のページに戻るようにした。
2. データリスト画面で、`lastUpdate`パラメータに基づいて背景色を適用するようにした。

## 修正内容の詳細
- 修正箇所:
  - **`app/routes/auth/asset/*`**
  - **`app/routes/auth/expense/*`**
  - **`app/routes/auth/income/*`**
- クエリパラメータの活用により、ユーザー体験を向上させた。
- UIを視覚的に改善し（背景ハイライト）、更新されたデータが明確に分かるようにした。

## 動作確認
- データを編集後、該当ページに戻り、編集したデータがハイライトされることを確認済み。

## 関連Issue
Closes #12
