### PR TITLE
fix: 月間収支ページで前月に同カテゴリがない場合に差分が0になるバグを修正

### DIFF
--- a/app/routes/auth/dashboard/[year]/[month]/monthly_balance/index.tsx
+++ b/app/routes/auth/dashboard/[year]/[month]/monthly_balance/index.tsx
@@ -69,24 +69,29 @@ export default createRoute(async (c) => {
   });
 
   const tableItems: ExpenseTableItems = {};
-  for (const elm of expenseValueData.summary) {
-    tableItems[elm.category_id] = {
-      categoryName: elm.category_name,
-      now: elm.total_amount,
+  // 一回ゼロで初期化
+  for (const elm of categories.contents) {
+    tableItems[elm.id] = {
+      categoryName: elm.name,
+      now: 0,
       prevDiff: 0,
     };
   }
+  // 今月の金額を記録
+  for (const elm of expenseValueData.summary) {
+    tableItems[elm.category_id] = {
+      ...tableItems[elm.category_id],
+      now: elm.total_amount,
+      prevDiff: elm.total_amount,
+    };
+  }
+  // 前月の金額と差分を記録
   for (const elm of prevExpenseValueData.summary) {
-    if (elm.category_id in tableItems) {
-      const now = tableItems[elm.category_id].now;
-      tableItems[elm.category_id].prevDiff = now - elm.total_amount;
-    } else {
-      tableItems[elm.category_id] = {
-        categoryName: elm.category_name,
-        now: 0,
-        prevDiff: -1 * elm.total_amount,
-      };
-    }
+    const item = tableItems[elm.category_id];
+    tableItems[elm.category_id] = {
+      ...tableItems[elm.category_id],
+      prevDiff: item.now - elm.total_amount,
+    };
   }
 
   const incomeValueData = await client.getSummaryResponse<SummaryResponse>({


### PR DESCRIPTION
## 🔧 修正内容

月間収支ページにおいて、**前月に同じカテゴリの支出がなかった場合に差分（`prevDiff`）が `+0` と表示されていたバグ**を修正しました。

---
## 🪛 修正前の挙動

2025年3月 交通費: 0円
2025年4月 交通費: 5,597円 → 差分: +0円 ❌
---
## ✅ 修正後の挙動
2025年4月 交通費: 5,597円 → 差分: +5,597円 ✅
---
## 🧩 対応内容
- カテゴリ一覧で初期化（`now: 0`, `prevDiff: 0`）
- 今月データに対して `now` を書き込み
- 前月データに対して `now` を参照し、`prevDiff = now - prev` を計算
- 前月にしか存在しないカテゴリも `now = 0` として扱い、負の差分を算出
---
## ✅ Close
Closes #24