### PR TITLE
複写時の日付を当日に変更 #29

### DIFF
--- a/app/islands/asset/AssetCreateModal.tsx
+++ b/app/islands/asset/AssetCreateModal.tsx
@@ -3,6 +3,7 @@ import type { FC, ChangeEvent } from "react";
 import { useState } from "react";
 import { Button } from "@/islands/Button";
 import { PageHeader } from "@/components/PageHeader";
+import { getTodayDate } from "@/utils/dateUtils";
 
 type Data = {
   date: string;
@@ -37,7 +38,7 @@ export const AssetCreateModal: FC<Props> = ({
     setOpen(true);
   };
   const [formData, setFormData] = useState<Data>({
-    date: data?.date || "",
+    date: data?.date || getTodayDate(),
     amount: data?.amount || "",
     asset_category_id: data?.asset_category_id || "",
     description: data?.description || "",

--- a/app/islands/expense/ExpenseCreateModal.tsx
+++ b/app/islands/expense/ExpenseCreateModal.tsx
@@ -6,6 +6,7 @@ import type {
 import { useState } from "react";
 import { Button } from "@/islands/Button";
 import { PageHeader } from "@/components/PageHeader";
+import { getTodayDate } from "@/utils/dateUtils";
 
 type Data = {
   date: string;
@@ -27,17 +28,6 @@ type CreateFormProps = {
 type Props = CreateFormProps & {
   buttonType: "primary" | "success";
   buttonTitle: string;
-};
-const getTodayDate = () => {
-  const now = new Date();
-  // UTC+9（日本時間）を適用
-  const jstDate = new Date(now.getTime() + 9 * 60 * 60 * 1000);
-  // 年、月、日を取得
-  const year = jstDate.getUTCFullYear();
-  const month = String(jstDate.getUTCMonth() + 1).padStart(2, "0"); // 月は0始まりのため+1
-  const day = String(jstDate.getUTCDate()).padStart(2, "0");
-  // yyyy-mm-dd形式で返す
-  return `${year}-${month}-${day}`;
 };
 
 export const ExpenseCreateModal: FC<Props> = ({

--- a/app/islands/fund_transation/FundTransactionCreateModal.tsx
+++ b/app/islands/fund_transation/FundTransactionCreateModal.tsx
@@ -2,6 +2,7 @@ import type { FC, ChangeEvent } from "react";
 import { useState } from "react";
 import { Button } from "@/islands/Button";
 import { PageHeader } from "@/components/PageHeader";
+import { getTodayDate } from "@/utils/dateUtils";
 
 type Data = {
   date: string;
@@ -33,7 +34,7 @@ export const FundTransactionCreateModal: FC<Props> = ({
     setOpen(true);
   };
   const [formData, setFormData] = useState<Data>({
-    date: data?.date || "",
+    date: data?.date || getTodayDate(),
     amount: data?.amount || "",
     description: data?.description || "",
     error: data?.error,

--- a/app/islands/income/IncomeCreateModal.tsx
+++ b/app/islands/income/IncomeCreateModal.tsx
@@ -3,6 +3,7 @@ import type { IncomeCategoryResponse } from "@/@types/dbTypes";
 import { useState } from "react";
 import { Button } from "@/islands/Button";
 import { PageHeader } from "@/components/PageHeader";
+import { getTodayDate } from "@/utils/dateUtils";
 
 type Data = {
   date: string;
@@ -37,7 +38,7 @@ export const IncomeCreateModal: FC<Props> = ({
     setOpen(true);
   };
   const [formData, setFormData] = useState<Data>({
-    date: data?.date || "",
+    date: data?.date || getTodayDate(),
     amount: data?.amount || "",
     income_category_id: data?.income_category_id || "",
     description: data?.description || "",

--- a/app/routes/auth/asset/index.tsx
+++ b/app/routes/auth/asset/index.tsx
@@ -15,6 +15,7 @@ import {
 import { getQueryString } from "@/utils/getQueryString";
 import { fetchListWithFilter, fetchSimpleList } from "@/libs/dbService";
 import { kakeiboPerPage } from "@/settings/kakeiboSettings";
+import { getTodayDate } from "@/utils/dateUtils";
 
 export default createRoute(async (c) => {
   const db = c.env.DB;
@@ -109,7 +110,7 @@ export default createRoute(async (c) => {
                     buttonType="primary"
                     buttonTitle="複写"
                     data={{
-                      date: asset.date,
+                      date: getTodayDate(),
                       amount: String(asset.amount),
                       asset_category_id: String(asset.asset_category_id),
                       description: asset.description ?? "",

--- a/app/routes/auth/expense/index.tsx
+++ b/app/routes/auth/expense/index.tsx
@@ -18,6 +18,7 @@ import { kakeiboPerPage } from "@/settings/kakeiboSettings";
 import { getBeginningOfMonth, getEndOfMonth } from "@/utils/dashboardUtils";
 import { getQueryString } from "@/utils/getQueryString";
 import { fetchListWithFilter, fetchSimpleList } from "@/libs/dbService";
+import { getTodayDate } from "@/utils/dateUtils";
 
 export default createRoute(async (c) => {
   const db = c.env.DB;
@@ -161,7 +162,7 @@ export default createRoute(async (c) => {
                     buttonType="primary"
                     buttonTitle="複写"
                     data={{
-                      date: expense.date,
+                      date: getTodayDate(),
                       amount: String(expense.amount),
                       expense_category_id: String(expense.expense_category_id),
                       payment_method_id: String(expense.payment_method_id),

--- a/app/routes/auth/fund_transaction/index.tsx
+++ b/app/routes/auth/fund_transaction/index.tsx
@@ -12,6 +12,7 @@ import { Table } from "@/components/share/Table";
 import { getQueryString } from "@/utils/getQueryString";
 import { fetchListWithFilter } from "@/libs/dbService";
 import { kakeiboPerPage } from "@/settings/kakeiboSettings";
+import { getTodayDate } from "@/utils/dateUtils";
 
 export default createRoute(async (c) => {
   const db = c.env.DB;
@@ -89,7 +90,7 @@ export default createRoute(async (c) => {
                     buttonType="primary"
                     buttonTitle="複写"
                     data={{
-                      date: tx.date,
+                      date: getTodayDate(),
                       amount: String(tx.amount),
                       description: tx.description || "",
                     }}

--- a/app/routes/auth/income/index.tsx
+++ b/app/routes/auth/income/index.tsx
@@ -13,6 +13,7 @@ import { successAlertCookieKey } from "@/settings/kakeiboSettings";
 import { getQueryString } from "@/utils/getQueryString";
 import { fetchListWithFilter, fetchSimpleList } from "@/libs/dbService";
 import { kakeiboPerPage } from "@/settings/kakeiboSettings";
+import { getTodayDate } from "@/utils/dateUtils";
 
 export default createRoute(async (c) => {
   const db = c.env.DB;
@@ -105,7 +106,7 @@ export default createRoute(async (c) => {
                     buttonType="primary"
                     buttonTitle="複写"
                     data={{
-                      date: income.date,
+                      date: getTodayDate(),
                       amount: String(income.amount),
                       income_category_id: String(income.income_category_id),
                       description: income.description || "",

--- a/app/utils/dateUtils.ts
+++ b/app/utils/dateUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * 現在の日付を日本時間（UTC+9）で取得し、yyyy-mm-dd形式で返す
+ * @returns {string} 現在の日付（yyyy-mm-dd形式）
+ */
+export const getTodayDate = (): string => {
+  const now = new Date();
+  // UTC+9（日本時間）を適用
+  const jstDate = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  // 年、月、日を取得
+  const year = jstDate.getUTCFullYear();
+  const month = String(jstDate.getUTCMonth() + 1).padStart(2, "0"); // 月は0始まりのため+1
+  const day = String(jstDate.getUTCDate()).padStart(2, "0");
+  // yyyy-mm-dd形式で返す
+  return `${year}-${month}-${day}`;
+};


### PR DESCRIPTION
## Summary
  - 複写機能利用時の日付が複写元となっているが、当日の日付の方が動作として
  望ましいため修正
  - 全ての複写機能（asset、expense、fund_transaction、income）で当日の日付
  を使用するよう変更

  ## Changes
  - `getTodayDate`関数を`utils/dateUtils.ts`に共通化
  - 各CreateModalで`getTodayDate()`をフォールバック値として使用
  - 複写時のデータで`getTodayDate()`を使用するよう変更

  Closes #29