### PR TITLE
fix: 資産追加時のカテゴリチェックのバグを修正 #28

### DIFF
--- a/app/routes/auth/asset/create.tsx
+++ b/app/routes/auth/asset/create.tsx
@@ -1,14 +1,16 @@
-import type { Asset } from "@/@types/dbTypes";
+import type { Asset, AssetWithCategoryResponse } from "@/@types/dbTypes";
 import { createRoute } from "honox/factory";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { setCookie } from "hono/cookie";
 import {
   alertCookieMaxage,
+  dangerAlertCookieKey,
   successAlertCookieKey,
 } from "@/settings/kakeiboSettings";
 import { sendSlackNotification } from "@/libs/slack";
-import { createItem } from "@/libs/dbService";
+import { createItem, fetchListWithFilter } from "@/libs/dbService";
+import { getBeginningOfMonth, getEndOfMonth } from "@/utils/dashboardUtils";
 
 const endPoint = "asset";
 const successMessage = "資産追加に成功しました";
@@ -34,6 +36,27 @@ export const POST = createRoute(
     const { date, amount, asset_category_id, description } =
       c.req.valid("form");
 
+    const [yearStr, monthStr] = date.split("-");
+    const year = parseInt(yearStr, 10); // 年
+    const month = parseInt(monthStr, 10); // 月
+    const ge = getBeginningOfMonth(year, month);
+    const le = getEndOfMonth(year, month);
+    const r = await fetchListWithFilter<AssetWithCategoryResponse>({
+      db: c.env.DB,
+      table: endPoint,
+      filters: `asset_category_id[eq]${asset_category_id}[and]date[greater_equal]${ge}[and]date[less_equal]${le}`,
+      limit: 10,
+      offset: 0,
+    });
+    if (r.totalCount > 0) {
+      setCookie(
+        c,
+        dangerAlertCookieKey,
+        "資産追加に失敗しました。同月に同カテゴリの資産が登録されています。",
+        { maxAge: alertCookieMaxage }
+      );
+      return c.redirect("/auth/asset", 303);
+    }
     const data = {
       date,
       amount: Number(amount),
@@ -66,5 +89,5 @@ ${newItem.date}
       console.error(`${endPoint} create error:`, err);
       return c.json({ error: `Failed to add ${endPoint}` }, 500);
     }
-  },
+  }
 );


### PR DESCRIPTION
## Summary
  - 同月に同じ資産カテゴリを追加した場合のエラーチェック機能を修正
  - workerに移行時に抜けていた実装を復活
  - 複写登録時の月変更忘れによる重複登録を防止

  ## Changes
  - 資産作成・更新時の同月同カテゴリ重複チェックロジックを修正
  - エラーメッセージの表示機能を復活

Closes #28