### PR TITLE
feat: 定期支払いチェック後の支出追加機能を実装 #33

### DIFF
--- a/app/routes/auth/expense_check/create.tsx
+++ b/app/routes/auth/expense_check/create.tsx
@@ -1,0 +1,115 @@
+import type { Expense } from "@/@types/dbTypes";
+import { createRoute } from "honox/factory";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { setCookie } from "hono/cookie";
+import {
+  alertCookieMaxage,
+  successAlertCookieKey,
+} from "@/settings/kakeiboSettings";
+import { sendSlackNotification } from "@/libs/slack";
+import { createItem } from "@/libs/dbService";
+
+const endPoint = "expense";
+const successMessage = "支出追加に成功しました";
+const slackSuccessMessage = "支出が追加されました。";
+
+/* --------------------- バリデーション --------------------- */
+const schema = z.object({
+  date: z.string().length(10),
+  amount: z.string().regex(/^\d+$/), // 数値文字列のみ許可
+  expense_category_id: z.string().regex(/^\d+$/),
+  payment_method_id: z.string().regex(/^\d+$/),
+  description: z.string(),
+});
+
+export const POST = createRoute(
+  zValidator("form", schema, (result, c) => {
+    if (!result.success) {
+      // バリデーションエラー時もdateから年月を取得してリダイレクト
+      let redirectYear, redirectMonth;
+      try {
+        const dateValue = result.data.date;
+        if (dateValue) {
+          const dateObj = new Date(dateValue);
+          redirectYear = dateObj.getFullYear().toString();
+          redirectMonth = (dateObj.getMonth() + 1).toString();
+        } else {
+          throw new Error("No date provided");
+        }
+      } catch {
+        // dateが無効な場合は現在の年月を使用
+        const now = new Date();
+        redirectYear = now.getFullYear().toString();
+        redirectMonth = (now.getMonth() + 1).toString();
+      }
+      
+      return c.redirect(`/auth/expense_check?year=${redirectYear}&month=${redirectMonth}`, 303);
+    }
+  }),
+  async (c) => {
+    /* フォーム値を取得＆型変換 */
+    const {
+      date,
+      amount,
+      expense_category_id,
+      payment_method_id,
+      description,
+    } = c.req.valid("form");
+
+    const data = {
+      date,
+      amount: Number(amount),
+      expense_category_id: Number(expense_category_id),
+      payment_method_id: Number(payment_method_id),
+      description,
+    };
+
+    try {
+      const newItem = await createItem<Expense>({
+        db: c.env.DB,
+        table: endPoint,
+        data,
+      });
+
+      /* ---------- 成功後の処理 ---------- */
+      setCookie(c, successAlertCookieKey, successMessage, {
+        maxAge: alertCookieMaxage,
+      });
+
+      const message = `
+${slackSuccessMessage}
+${newItem.date}
+カテゴリ: ${newItem.category_name}
+支払い方法: ${newItem.payment_method_name}
+金額: ${newItem.amount}
+詳細: ${newItem.description}
+      `.trim();
+      await sendSlackNotification(message, c.env.SLACK_WEBHOOK_URL);
+
+      // 入力されたdateから年月を取得してリダイレクトパラメータに設定
+      const dateObj = new Date(data.date);
+      const redirectYear = dateObj.getFullYear().toString();
+      const redirectMonth = (dateObj.getMonth() + 1).toString();
+      
+      return c.redirect(`/auth/expense_check?year=${redirectYear}&month=${redirectMonth}`, 303);
+    } catch (err) {
+      console.error(`${endPoint} create error:`, err);
+      
+      // エラー時もdateから年月を取得してリダイレクト（フォールバック付き）
+      let redirectYear, redirectMonth;
+      try {
+        const dateObj = new Date(data.date);
+        redirectYear = dateObj.getFullYear().toString();
+        redirectMonth = (dateObj.getMonth() + 1).toString();
+      } catch {
+        // dateが無効な場合は現在の年月を使用
+        const now = new Date();
+        redirectYear = now.getFullYear().toString();
+        redirectMonth = (now.getMonth() + 1).toString();
+      }
+      
+      return c.redirect(`/auth/expense_check?year=${redirectYear}&month=${redirectMonth}&error=create_failed`, 303);
+    }
+  },
+);


### PR DESCRIPTION
## Summary
  定期支払いチェック機能において、未登録項目を発見した際にその場で支出を追
  加できる機能を実装しました。

  Closes #33

  ## 実装した機能

  ### ✅ 未登録項目への直接追加機能
  - 未登録項目に「追加」ボタンを表示
  - ExpenseCreateModalを再利用して実装
  - 適切な初期値を自動設定（日付、カテゴリ、説明文）

  ### ✅ 動的リダイレクト機能
  - フォーム入力のdateから年月を自動抽出
  - リダイレクト時に適切な年月パラメータを設定
  - エラー時も現在の年月にフォールバック

  ### ✅ UX改善
  - 成功メッセージの表示（Alert コンポーネント）
  - 登録後は該当月のチェック画面に自動で戻る
  - テンプレートの情報を活用した初期値設定

  ## 技術的な実装

  ### 新規ファイル
  - `app/routes/auth/expense_check/create.tsx`
    - 支出登録処理とリダイレクト制御
    - 入力日付からの年月パラメータ抽出

  ### 既存ファイルの拡張
  - `app/routes/auth/expense_check/index.tsx`
    - ExpenseCreateModal の統合
    - 支出カテゴリ・支払い方法データの取得
    - 成功メッセージ表示機能

  ## 使用フロー
  1. 定期支払いチェック画面で未登録項目を確認
  2. 未登録項目の「追加」ボタンをクリック
  3. モーダルが開き、以下が自動設定される：
     - 日付: 選択中の年月 + 現在の日
     - カテゴリ: テンプレートのカテゴリ
     - 説明: テンプレートの検索パターン
  4. 支出情報を入力・送信
  5. 登録成功後、入力した日付の年月でチェック画面にリダイレクト
  6. 成功メッセージ表示と更新されたチェック結果を確認